### PR TITLE
python script for sending email through command

### DIFF
--- a/Submissions/kavi-12/#task-3/send_email.py
+++ b/Submissions/kavi-12/#task-3/send_email.py
@@ -1,0 +1,24 @@
+# Importing the libraries
+import  smtplib
+
+# Initializing
+smtp_obj = smtplib.SMTP('smtp.gmail.com', 587)
+smtp_obj.ehlo()
+smtp_obj.starttls()
+# logging in own gmail account
+import getpass
+email = getpass.getpass('email:')
+password = getpass.getpass('password: ')
+smtp_obj.login(email,password)
+# Receiver's address
+send_add = input('receiver email address: ')
+
+# Sending mail
+from_add = email
+to_add = send_add
+subject = input('Subject:')
+message = input('message:')
+msg = 'Subject:' + subject + '\n' + message
+
+smtp_obj.sendmail(from_add, to_add, msg)
+


### PR DESCRIPTION
__21__ 

#### Short description of what this resolves:

Python script enable to send email through python3 terminal .
To send email, you cannot use your gmail password, instead you have to turn on your 2-step verification from google accounts and generate app password and use that password



#### Changes proposed in this pull request and/or Screenshots of changes:

-
-
-



