### PR TITLE
Added python script to clump all similar files into respective folders

### DIFF
--- a/Submissions/Yolo86/Task_2/files.py
+++ b/Submissions/Yolo86/Task_2/files.py
@@ -1,0 +1,16 @@
+import os
+import shutil
+
+os.chdir('../../../Task_2/My_Files/')
+b = os.getcwd()
+
+for fi in os.listdir():
+	try:
+		fna,fext = fi.split('.')
+		if os.path.exists(b+'/'+fext):
+			shutil.move(b+'/'+fi,b+'/'+fext+'/'+fi)
+		else:
+			os.makedirs(b+'/'+fext)
+			shutil.move(b+'/'+fi,b+'/'+fext+'/'+fi)
+	except ValueError:
+		continue


### PR DESCRIPTION
__3__ 

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
<!-- Add issue numbers both above and below this comment, do not remove __ or #-->


#### Short description of what this resolves:
The Python script in Submissions\Yolo86\Task_2\ when run will put similar files present in Task_2\My_Files\ into respective folders.
Eg - all .pdf files will be put in pdf folder, all .doc files will be put into doc folder,etc




#### Changes proposed in this pull request and/or Screenshots of changes:

-![Screenshot (2)](https://user-images.githubusercontent.com/54069125/72916255-b8d34200-3d67-11ea-8571-888daabd8c5f.png)
-
-



